### PR TITLE
Bugfix/misc fixes

### DIFF
--- a/bin/gemini
+++ b/bin/gemini
@@ -44,6 +44,7 @@ use Kobens\Gemini\TradeRepeater\Watcher\Helper\Data;
 use Zend\Db\TableGateway\TableGateway;
 use Kobens\Gemini\TradeRepeater\Model\GetRecordId;
 use Kobens\Gemini\TradeRepeater\Model\Trade\ShouldResetBuy;
+use Kobens\Gemini\TradeRepeater\Watcher\Profits;
 
 require \dirname(__DIR__).'/bootstrap.php';
 
@@ -295,7 +296,8 @@ $app->add(new \Kobens\Gemini\Command\Command\TradeRepeater\Watcher(
         $getPriceInterface
     ),
     $sleeperInterface,
-    $getPriceInterface
+    $getPriceInterface,
+    new Profits($adapter)
 ));
 
 

--- a/bin/gemini
+++ b/bin/gemini
@@ -42,6 +42,7 @@ use Kobens\Gemini\TradeRepeater\Model\Resource\Trade\Action\SellPlaced;
 use Kobens\Gemini\TradeRepeater\Model\Resource\Trade\Action\SellSent;
 use Kobens\Gemini\TradeRepeater\Watcher\Helper\Data;
 use Zend\Db\TableGateway\TableGateway;
+use Kobens\Gemini\TradeRepeater\Model\GetRecordId;
 
 require \dirname(__DIR__).'/bootstrap.php';
 
@@ -183,7 +184,8 @@ $app->add(new \Kobens\Gemini\Command\Command\TradeRepeater\FillMonitor\WebSocket
     $nonceInterface,
     $buyPlacedInterface,
     $sellPlacedInterface,
-    $sleeperInterface
+    $sleeperInterface,
+    new GetRecordId()
 ));
 
 $restFillMonitorKey = new Key(

--- a/bin/gemini
+++ b/bin/gemini
@@ -43,6 +43,7 @@ use Kobens\Gemini\TradeRepeater\Model\Resource\Trade\Action\SellSent;
 use Kobens\Gemini\TradeRepeater\Watcher\Helper\Data;
 use Zend\Db\TableGateway\TableGateway;
 use Kobens\Gemini\TradeRepeater\Model\GetRecordId;
+use Kobens\Gemini\TradeRepeater\Model\Trade\ShouldResetBuy;
 
 require \dirname(__DIR__).'/bootstrap.php';
 
@@ -283,7 +284,8 @@ $app->add(new \Kobens\Gemini\Command\Command\TradeRepeater\Auditor\BuyPrice(
     new OrderStatus($buyAuditorRequestInterface),
     new CancelOrder($buyAuditorRequestInterface),
     $adapter,
-    $sleeperInterface
+    $sleeperInterface,
+    new ShouldResetBuy($orderStatusInterface, $getPriceInterface)
 ));
 unset($buyAuditorKey, $buyAuditorRequestInterface);
 $app->add(new \Kobens\Gemini\Command\Command\TradeRepeater\Watcher(

--- a/bootstrap-genorder.php
+++ b/bootstrap-genorder.php
@@ -115,7 +115,7 @@ class GenOrder
             }
 
             for ($i = 0, $j = \count($orders); $i < $j; $i++) {
-                $clientOrderId = 'trade_repeater_' . $action . '_' . $this->pair->getSymbol() . ((string) microtime(true));
+                $clientOrderId = 'repeater_' . $action . '_' . $this->pair->getSymbol() . ((string) microtime(true));
                 $r = $this->makerOrCancel->place(
                     $this->pair,
                     $action,

--- a/checkOrders.php
+++ b/checkOrders.php
@@ -61,7 +61,7 @@ function examineOrders(array &$orderBatches): array
     foreach (getActiveOrders()->getOrders() as $order) {
         if (
             !($order->client_order_id ?? null) ||
-            strpos($order->client_order_id, 'trade_repeater_') !== 0
+            strpos($order->client_order_id, 'repeater_') !== 0
         ) {
             continue;
         }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "require": {
         "php": "^7.4",
         "ext-bcmath": "*",
+        "ext-ctype": "*",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/src/Command/Command/TradeRepeater/Archiver.php
+++ b/src/Command/Command/TradeRepeater/Archiver.php
@@ -68,7 +68,11 @@ final class Archiver extends Command
                 $this->shutdown->enableShutdownMode($e);
             }
         }
-        $output->writeln("\n<fg=red>{$this->now()}\tShutdown signal detected.\n");
+        $output->writeln(sprintf(
+            "<fg=red>%s\tShutdown signal detected - %s",
+            $this->now(),
+            self::class
+        ));
     }
 
     private function mainLoop(OutputInterface $output): void

--- a/src/Command/Command/TradeRepeater/Auditor/BuyPrice.php
+++ b/src/Command/Command/TradeRepeater/Auditor/BuyPrice.php
@@ -97,7 +97,11 @@ final class BuyPrice extends Command
             }
         }
 
-        $output->writeln("\n<fg=red>{$this->now()}\tShutdown signal detected.\n");
+        $output->writeln(sprintf(
+            "<fg=red>%s\tShutdown signal detected - %s",
+            $this->now(),
+            self::class
+        ));
     }
 
     private function exceptionDelay(OutputInterface $output, \Exception $e)

--- a/src/Command/Command/TradeRepeater/Auditor/SellPrice.php
+++ b/src/Command/Command/TradeRepeater/Auditor/SellPrice.php
@@ -97,7 +97,11 @@ final class SellPrice extends Command
             }
         }
 
-        $output->writeln("\n<fg=red>{$this->now()}\tShutdown signal detected.\n");
+        $output->writeln(sprintf(
+            "<fg=red>%s\tShutdown signal detected - %s",
+            $this->now(),
+            self::class
+        ));
     }
 
     private function exceptionDelay(OutputInterface $output, \Exception $e)

--- a/src/Command/Command/TradeRepeater/Buyer.php
+++ b/src/Command/Command/TradeRepeater/Buyer.php
@@ -86,7 +86,11 @@ final class Buyer extends Command
                 $this->shutdown->enableShutdownMode($e);
             }
         }
-        $output->writeln("\n<fg=red>{$this->now()}\tShutdown signal detected.\n");
+        $output->writeln(sprintf(
+            "<fg=red>%s\tShutdown signal detected - %s",
+            $this->now(),
+            self::class
+        ));
     }
 
     private function mainLoop(InputInterface $input, OutputInterface $output): bool

--- a/src/Command/Command/TradeRepeater/FillMonitor/Rest.php
+++ b/src/Command/Command/TradeRepeater/FillMonitor/Rest.php
@@ -69,7 +69,11 @@ final class Rest extends Command
                 $this->shutdown->enableShutdownMode($e);
             }
         }
-        $output->writeln("\n<fg=red>{$this->now()}\tShutdown signal detected.\n");
+        $output->writeln(sprintf(
+            "<fg=red>%s\tShutdown signal detected - %s",
+            $this->now(),
+            self::class
+        ));
     }
 
     private function exceptionDelay(OutputInterface $output, \Exception $e)

--- a/src/Command/Command/TradeRepeater/FillMonitor/WebSocket.php
+++ b/src/Command/Command/TradeRepeater/FillMonitor/WebSocket.php
@@ -117,9 +117,6 @@ final class WebSocket extends Command
     private function processMessage(array $msg, OutputInterface $output): void
     {
         switch (true) {
-            case $msg['type'] === 'subscription_ack':
-                $output->writeln($this->now() . "\tSubscription acknowledged.");
-                break;
             case $msg['type'] === 'heartbeat':
                 if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
                     $output->writeln($this->now() . "\tHeartbeat Received");
@@ -173,6 +170,13 @@ final class WebSocket extends Command
                             break;
                     }
                 }
+                break;
+            case $msg['type'] === 'subscription_ack':
+                $output->writeln(sprintf(
+                    "%s\tSubscription acknowledged - %s",
+                    $this->now(),
+                    self::class
+                ));
                 break;
             default:
                 throw new \Exception('Unhandled Message: ' . \json_encode($msg));

--- a/src/Command/Command/TradeRepeater/FillMonitor/WebSocket.php
+++ b/src/Command/Command/TradeRepeater/FillMonitor/WebSocket.php
@@ -82,7 +82,11 @@ final class WebSocket extends Command
                 $this->shutdown->enableShutdownMode($e);
             }
         }
-        $output->writeln("\n<fg=red>{$this->now()}\tShutdown signal detected.\n");
+        $output->writeln(sprintf(
+            "<fg=red>%s\tShutdown signal detected - %s",
+            $this->now(),
+            self::class
+        ));
     }
 
     private function main(OutputInterface $output): \Closure

--- a/src/Command/Command/TradeRepeater/PricePointGenerator.php
+++ b/src/Command/Command/TradeRepeater/PricePointGenerator.php
@@ -62,16 +62,16 @@ final class PricePointGenerator extends Command
                     $position->getSellAmountBase(),
                     $position->getSellPrice()
                 ));
-                $this->table->insert([
-                    'is_enabled' => $isEnabled,
-                    'status' => 'BUY_READY',
-                    'symbol' => $pair->getSymbol(),
-                    'buy_amount' => $position->getBuyAmountBase(),
-                    'buy_price' => $position->getBuyPrice(),
-                    'sell_amount' => $position->getSellAmountBase(),
-                    'sell_price' => $position->getSellPrice(),
-                ]);
             }
+            $this->table->insert([
+                'is_enabled' => $isEnabled,
+                'status' => 'BUY_READY',
+                'symbol' => $pair->getSymbol(),
+                'buy_amount' => $position->getBuyAmountBase(),
+                'buy_price' => $position->getBuyPrice(),
+                'sell_amount' => $position->getSellAmountBase(),
+                'sell_price' => $position->getSellPrice(),
+            ]);
         }
         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
             $output->writeln(sprintf(

--- a/src/Command/Command/TradeRepeater/Seller.php
+++ b/src/Command/Command/TradeRepeater/Seller.php
@@ -85,7 +85,11 @@ final class Seller extends Command
                 $this->shutdown->enableShutdownMode($e);
             }
         }
-        $output->writeln("\n<fg=red>{$this->now()}\tShutdown signal detected.\n");
+        $output->writeln(sprintf(
+            "<fg=red>%s\tShutdown signal detected - %s",
+            $this->now(),
+            self::class
+        ));
     }
 
     private function mainLoop(InputInterface $input, OutputInterface $output): bool

--- a/src/Command/Command/TradeRepeater/Watcher.php
+++ b/src/Command/Command/TradeRepeater/Watcher.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Kobens\Gemini\TradeRepeater\Watcher\Profits;
 
 final class Watcher extends Command
 {
@@ -34,14 +35,18 @@ final class Watcher extends Command
 
     private GetPriceInterface $getPrice;
 
+    private Profits $profits;
+
     public function __construct(
         Data $data,
         SleeperInterface $sleeperInterface,
-        GetPriceInterface $getPrice
+        GetPriceInterface $getPrice,
+        Profits $profits
     ) {
         $this->data = $data;
         $this->sleeper = $sleeperInterface;
         $this->getPrice = $getPrice;
+        $this->profits = $profits;
         parent::__construct();
     }
 
@@ -188,6 +193,7 @@ final class Watcher extends Command
                 }
             }
             $data[] = Balances::getTable($output, $this->data, $showNotional, $showAvailable, $showAvailableNotional);
+            $data[] = $this->profits->get($output);
             if ($input->getOption('price')) {
                 $tblPrice = new Table($output);
                 $tblPrice->setHeaders(['Asset Pair', 'Asking Price']);

--- a/src/TradeRepeater/Model/GetRecordId.php
+++ b/src/TradeRepeater/Model/GetRecordId.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kobens\Gemini\TradeRepeater\Model;
+
+final class GetRecordId implements GetRecordIdInterface
+{
+    public function get(string $clientOrderId): int
+    {
+        $id = \explode('_', $clientOrderId)[1] ?? '';
+        if (ctype_digit($id)) {
+            $id = (int) $id;
+        }
+        if (!is_int($id) || $id === 0 || strpos($clientOrderId, 'repeater_') !== 0) {
+            throw new \InvalidArgumentException(sprintf(
+                'Client Order ID "%s" does is not a valid TradeRepeater format.',
+                $clientOrderId
+            ));
+        }
+        return $id;
+    }
+}

--- a/src/TradeRepeater/Model/GetRecordIdInterface.php
+++ b/src/TradeRepeater/Model/GetRecordIdInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kobens\Gemini\TradeRepeater\Model;
+
+interface GetRecordIdInterface
+{
+    /**
+     * @param string $clientOrderId
+     * @throws \InvalidArgumentException
+     * @return int
+     */
+    public function get(string $clientOrderId): int;
+}

--- a/src/TradeRepeater/Model/Trade.php
+++ b/src/TradeRepeater/Model/Trade.php
@@ -38,6 +38,26 @@ final class Trade
 
     private ?string $updatedAt;
 
+    /**
+     * FIXME: ID last, as it has a default value
+     *
+     * @param int $id
+     * @param int $isEnabled
+     * @param int $isError
+     * @param string $status
+     * @param string $symbol
+     * @param string $buyAmount
+     * @param string $buyPrice
+     * @param string $sellAmount
+     * @param string $sellPrice
+     * @param string $buyClientOrderId
+     * @param int $buyOrderId
+     * @param string $sellClientOrderId
+     * @param int $sellOrderId
+     * @param string $note
+     * @param string $meta
+     * @param string $updatedAt
+     */
     public function __construct(
         int $id = null,
         int $isEnabled,

--- a/src/TradeRepeater/Model/Trade/ShouldResetBuy.php
+++ b/src/TradeRepeater/Model/Trade/ShouldResetBuy.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kobens\Gemini\TradeRepeater\Model\Trade;
+
+use Kobens\Gemini\Api\Rest\PrivateEndpoints\OrderStatus\OrderStatusInterface;
+use Kobens\Gemini\TradeRepeater\Model\Trade;
+use Kobens\Math\PercentDifference;
+use Kobens\Math\BasicCalculator\Compare;
+use Kobens\Gemini\Api\Market\GetPriceInterface;
+
+final class ShouldResetBuy implements ShouldResetBuyInterface
+{
+    /**
+     * @var OrderStatusInterface
+     */
+    private OrderStatusInterface $orderStatus;
+
+    /**
+     * @var GetPriceInterface
+     */
+    private GetPriceInterface $getPrice;
+
+    /**
+     * Minimum age in seconds an order must be to be valid for a reset.
+     *
+     * @var int
+     */
+    private int $minAge;
+
+    /**
+     * Minimum spread (percentage wise) from the current prices an order
+     * must to be valid for a reset.
+     *
+     * '1' equates to 1% difference, '2' equates to 2%, etc.
+     *
+     * Supports fractions of a percent up to any precision level. For example
+     * '1.12345' would accurately enforce 1.12345% percent.
+     *
+     * @var string
+     */
+    private string $minSpread;
+
+    /**
+     * TODO: add private setMinAge() and setMinSpread() functions that validate input and
+     * throw exception on invalid arguments.
+     *
+     * @param OrderStatusInterface $orderStatus
+     * @param int $minAge
+     * @param string $minSpread
+     */
+    public function __construct(
+        OrderStatusInterface $orderStatus,
+        GetPriceInterface $getPrice,
+        int $minAge = 1800,
+        string $minSpread = '2'
+    ) {
+        $this->orderStatus = $orderStatus;
+        $this->getPrice = $getPrice;
+        $this->minAge = $minAge;
+        $this->minSpread = $minSpread;
+    }
+
+    /**
+     * @param Trade $trade
+     * @return bool
+     */
+    public function get(Trade $trade): bool
+    {
+        $meta = \json_decode($trade->getMeta());
+        return
+            Compare::getResult($trade->getBuyPrice(), $meta->buy_price) !== Compare::EQUAL &&
+            \time() - \strtotime($trade->getUpdatedAt()) > $this->minAge &&
+            Compare::getResult(
+                PercentDifference::getResult($meta->buy_price, $this->getPrice->getBid($trade->getSymbol())),
+                $this->minSpread
+            ) === Compare::LEFT_GREATER_THAN &&
+            Compare::getResult($this->orderStatus->getStatus($trade->getBuyOrderId())->executed_amount, '0') === Compare::EQUAL;
+    }
+}

--- a/src/TradeRepeater/Model/Trade/ShouldResetBuyInterface.php
+++ b/src/TradeRepeater/Model/Trade/ShouldResetBuyInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kobens\Gemini\TradeRepeater\Model\Trade;
+
+use Kobens\Gemini\TradeRepeater\Model\Trade;
+
+interface ShouldResetBuyInterface
+{
+
+    /**
+     * @param Trade $trade
+     * @return bool
+     */
+    public function get(Trade $trade): bool;
+}

--- a/src/TradeRepeater/Watcher/MarketSpread.php
+++ b/src/TradeRepeater/Watcher/MarketSpread.php
@@ -30,7 +30,7 @@ final class MarketSpread
         $table
             ->setHeaders(
                 [
-                    new TableCell('<options=underscore>Market Data</>', ['colspan' => 2])
+                    new TableCell(sprintf('<options=underscore>Market Data</> %s', $symbol), ['colspan' => 2])
                 ]
             )
             ->setRows(

--- a/src/TradeRepeater/Watcher/Profits.php
+++ b/src/TradeRepeater/Watcher/Profits.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kobens\Gemini\TradeRepeater\Watcher;
+
+use Symfony\Component\Console\Helper\Table;
+use Zend\Db\TableGateway\TableGateway;
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\Sql\Select;
+use Symfony\Component\Console\Output\OutputInterface;
+use Kobens\Math\BasicCalculator\Multiply;
+use Kobens\Math\BasicCalculator\Subtract;
+use Kobens\Gemini\Exchange\Currency\Pair;
+use Kobens\Math\BasicCalculator\Compare;
+use Kobens\Math\BasicCalculator\Add;
+use Symfony\Component\Console\Helper\TableCell;
+
+final class Profits
+{
+    private TableGateway $table;
+
+    private Adapter $adapter;
+
+    public function __construct(
+        Adapter $adapter
+    ) {
+        $this->adapter = $adapter;
+        $this->table = new TableGateway('trade_repeater_archive', $adapter);
+    }
+
+    public function get(OutputInterface $output): Table
+    {
+        $profits = $this->getData();
+        $table = new Table($output);
+        $table->setHeaders(
+            [
+                new TableCell(sprintf('Profits Since %s', $profits['date']), ['colspan' => 2])
+            ]
+        );
+
+        foreach ($profits['profits'] as $symbol => $amount) {
+            $table->addRow([$symbol, $amount]);
+        }
+        return $table;
+    }
+
+    /**
+     * TODO: Filter by past month
+     */
+    private function getData()
+    {
+        $results = $this->table->select(function (Select $sql) {
+            $sql->order('created_at ASC');
+        });
+        $profits = [];
+        $date = null;
+        foreach ($results as $result) {
+            if ($date === null) {
+                $date = $result->created_at;
+            }
+            foreach ($this->getProfits($result) as $symbol => $amount) {
+                if (($profits[$symbol] ?? null) === null) {
+                    $profits[$symbol] = '0';
+                }
+                $profits[$symbol] = Add::getResult($profits[$symbol], $amount);
+            }
+        }
+        return [
+            'date' => $date,
+            'profits' => $profits,
+        ];
+    }
+
+    /**
+     * FIXME: Need to lookup actual transaction data from transaction table to ensure confidence in fee amount for order (right now we're assuming always a 10BPS)
+     *
+     * @param \stdClass $data
+     * @return array
+     */
+    private function getProfits($data): array
+    {
+        $buyAmount = Multiply::getResult($data->buy_amount, $data->buy_price);
+        $buyFee = Multiply::getResult($buyAmount, '0.0010');
+        $sellProceeds = Multiply::getResult($data->sell_amount, $data->sell_price);
+        $sellFee = Multiply::getResult($sellProceeds, '0.0010');
+
+        $baseProfits = Subtract::getResult($data->buy_amount, $data->sell_amount);
+        $quoteProfits = Subtract::getResult(
+            Subtract::getResult(
+                Subtract::getResult(
+                    $sellProceeds,
+                    $sellFee
+                ),
+                $buyAmount
+            ),
+            $buyFee
+        );
+
+        $pair = Pair::getInstance($data->symbol);
+
+        $result = [];
+        if (Compare::getResult('0', $baseProfits) === Compare::RIGHT_GREATER_THAN) {
+            $result[$pair->getBase()->getSymbol()] = $baseProfits;
+        }
+        if (Compare::getResult('0', $quoteProfits) === Compare::RIGHT_GREATER_THAN) {
+            $result[$pair->getQuote()->getSymbol()] = $quoteProfits;
+        }
+
+        return $result;
+    }
+}

--- a/src/TradeRepeater/Watcher/TradeSpread.php
+++ b/src/TradeRepeater/Watcher/TradeSpread.php
@@ -22,7 +22,7 @@ final class TradeSpread
             if (
                 $order->symbol === $symbol &&
                 ($order->client_order_id ?? null) &&
-                strpos($order->client_order_id, 'trade_repeater_') === 0
+                strpos($order->client_order_id, 'repeater_') === 0
             ) {
                 if (
                     $order->side === 'sell'

--- a/test/Unit/TradeRepeater/Model/GetRecordIdTest.php
+++ b/test/Unit/TradeRepeater/Model/GetRecordIdTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KobensTest\Gemini\Unit\TradeRepeater\Model;
+
+use Kobens\Gemini\TradeRepeater\Model\GetRecordId;
+use PHPUnit\Framework\TestCase;
+
+class GetRecordIdTest extends TestCase
+{
+    private ?GetRecordId $getRecordId = null;
+
+    protected function setUp(): void
+    {
+        $this->getRecordId = new GetRecordId();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->getRecordId = null;
+    }
+
+    public function testGetReturnsId(): void
+    {
+        $this->assertSame(1, $this->getRecordId->get('repeater_1_sell_1610309695.9983'));
+        $this->assertSame(2, $this->getRecordId->get('repeater_2_sell_1610328861.0035'));
+        $this->assertSame(299, $this->getRecordId->get('repeater_299_buy_1610328918.5095'));
+        $this->assertSame(1234, $this->getRecordId->get('repeater_1234_buy_1610328961.6939'));
+        $this->assertSame(100, $this->getRecordId->get('repeater_100'));
+    }
+
+    /**
+     * @dataProvider dataProviderInvalidFormat
+     */
+    public function testGetThrowsInvalidArgumentException(string $clientOrderId, $message): void
+    {
+        $this->expectExceptionObject(new \InvalidArgumentException($message));
+        $this->getRecordId->get($clientOrderId);
+    }
+
+    public function dataProviderInvalidFormat(): array
+    {
+        return [
+            ['foo', 'Client Order ID "foo" does is not a valid TradeRepeater format.'],
+            ['repeater1234_sell_1610321924.6922', 'Client Order ID "repeater1234_sell_1610321924.6922" does is not a valid TradeRepeater format.'],
+        ];
+    }
+}

--- a/test/Unit/TradeRepeater/Model/Trade/ShouldResetBuyTest.php
+++ b/test/Unit/TradeRepeater/Model/Trade/ShouldResetBuyTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KobensTest\Gemini\Unit\TradeRepeater\Model\Trade;
+
+use PHPUnit\Framework\TestCase;
+use Kobens\Gemini\TradeRepeater\Model\Trade\ShouldResetBuy;
+use Kobens\Gemini\TradeRepeater\Model\Trade;
+use Kobens\Gemini\Api\Rest\PrivateEndpoints\OrderStatus\OrderStatusInterface;
+use Kobens\Gemini\Api\Market\GetPriceInterface;
+
+class ShouldResetBuyTest extends TestCase
+{
+    private ?ShouldResetBuy $shouldReset = null;
+
+    private ?GetPriceInterface $getPrice = null;
+
+    private ?OrderStatusInterface $orderStatus = null;
+
+    protected function setUp(): void
+    {
+        $this->orderStatus = $this->createStub(OrderStatusInterface::class);
+        $this->getPrice = $this->createStub(GetPriceInterface::class);
+        $this->shouldReset = new ShouldResetBuy($this->orderStatus, $this->getPrice);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->shouldReset = null;
+        $this->getPrice = null;
+        $this->orderStatus = null;
+    }
+
+    /**
+     * @dataProvider dataProviderTestGetReturnsTrue
+     *
+     * @param Trade $trade                              Dummy Trade Record
+     * @param string $currentBidPrice                   Mocked out current quote price for bidding on the asset
+     */
+    public function testGetReturnsTrue(Trade $trade, string $currentBidPrice): void
+    {
+        $this->getPrice->method('getBid')->willReturn($currentBidPrice);
+        $this->orderStatus->method('getStatus')->willReturn(json_decode('{"executed_amount":"0"}'));
+        $this->assertTrue($this->shouldReset->get($trade));
+    }
+
+    public function dataProviderTestGetReturnsTrue(): array
+    {
+        return [
+            [
+                new Trade(
+                    null,
+                    1,
+                    0,
+                    'BUY_PLACED',
+                    'linkusd',
+                    '0.1',
+                    '12',
+                    '0.1',
+                    '12.6',
+                    'repeater_1_buy_1610330096.6266',
+                    1234,
+                    'repeater_1_sell_1610331096.6266',
+                    5678,
+                    null,
+                    '{"buy_price":"11.00"}',
+                    '2021-01-10 19:54:56'
+                ),
+                '20'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderTestGetReturnsFalse
+     *
+     * @param Trade $trade                              Dummy Trade Record
+     * @param string $currentBidPrice                   Mocked out current quote price for bidding on the asset
+     */
+    public function testGetReturnsFalse(Trade $trade, string $currentBidPrice, string $executedAmount): void
+    {
+        $this->getPrice->method('getBid')->willReturn($currentBidPrice);
+        $this->orderStatus->method('getStatus')->willReturn(json_decode('{"executed_amount":"' . $executedAmount . '"}'));
+        $this->assertFalse($this->shouldReset->get($trade));
+    }
+
+    /**
+     * TODO: Add scenarios for the following:
+     *  - minimum age threshold is too low
+     *  - spread between the market's current bid price, and out bid price, is too low
+     * With each scenario above, in order to properly test, make sure that is the only case causing
+     * a false result for the test case.
+     *
+     * @return array
+     */
+    public function dataProviderTestGetReturnsFalse(): array
+    {
+        return [
+            [
+                new Trade(
+                    null,
+                    1,
+                    0,
+                    'BUY_PLACED',
+                    'linkusd',
+                    '0.1',
+                    '12',
+                    '0.1',
+                    '12.6',
+                    'repeater_1_buy_1610330096.6266',
+                    1234,
+                    'repeater_1_sell_1610331096.6266',
+                    5678,
+                    null,
+                    '{"buy_price":"12.00"}',
+                    '2021-01-10 19:54:56'
+                ),
+                '20',
+                '0'
+            ],
+            [
+                new Trade(
+                    null,
+                    1,
+                    0,
+                    'BUY_PLACED',
+                    'linkusd',
+                    '0.1',
+                    '12',
+                    '0.1',
+                    '12.6',
+                    'repeater_1_buy_1610330096.6266',
+                    1234,
+                    'repeater_1_sell_1610331096.6266',
+                    5678,
+                    null,
+                    '{"buy_price":"11.59"}',
+                    '2021-01-10 19:54:56'
+                ),
+                '20',
+                '0.001'
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- (bugfix) Corrected start string searched for for `TradeRepeater` classes
- (bugfix) Fixed `PricePointGenerator` which wasn't inserting records into db table
- (feature) Added trading pair symbol to `MarketSpread` table
- (bugfix) Fixed #68 
- (feature) add class name to output during emergency shutdown
- (bugfix) fix parsing of the client_order_id 
- (feature) profits report for watcher