### PR TITLE
Misc touchups

### DIFF
--- a/bin/trade-repeater
+++ b/bin/trade-repeater
@@ -226,7 +226,7 @@ if [ $? -eq 1 ]; then
     php -n $(dirname $BASH_SOURCE)/gemini repeater:seller &
 fi
 
-ps aux | grep -v grep | grep -q gemini\ repeater:archiver
+ps aux | grep -v 'grep\|fill-time' | grep -q gemini\ repeater:archiver
 if [ $? -eq 1 ]; then
     php -n $(dirname $BASH_SOURCE)/gemini repeater:archiver &
 fi

--- a/composer.lock
+++ b/composer.lock
@@ -1038,12 +1038,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dfelton/kobens-core.git",
-                "reference": "60bb749737e28c92091d205cb3eca5cd13a398ab"
+                "reference": "31539f3e1d44b5a009912d0cabc53192111b6a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dfelton/kobens-core/zipball/60bb749737e28c92091d205cb3eca5cd13a398ab",
-                "reference": "60bb749737e28c92091d205cb3eca5cd13a398ab",
+                "url": "https://api.github.com/repos/dfelton/kobens-core/zipball/31539f3e1d44b5a009912d0cabc53192111b6a32",
+                "reference": "31539f3e1d44b5a009912d0cabc53192111b6a32",
                 "shasum": ""
             },
             "require": {
@@ -1081,7 +1081,7 @@
                 "source": "https://github.com/dfelton/kobens-core/tree/master",
                 "issues": "https://github.com/dfelton/kobens-core/issues"
             },
-            "time": "2021-02-08T19:43:29+00:00"
+            "time": "2021-02-15T19:41:09+00:00"
         },
         {
             "name": "kobens/kobens-currency",

--- a/src/Command/Command/TradeRepeater/AddToPosition.php
+++ b/src/Command/Command/TradeRepeater/AddToPosition.php
@@ -49,8 +49,25 @@ final class AddToPosition extends Command
         $priceFrom = $this->getArg($input, 'price-from');
         $priceTo = $this->getArg($input, 'price-to');
         if ($input->getOption('confirm') === '1') {
+            $addTo = $this->addAmount->addTo($pair->getSymbol(), $amount, $priceFrom, $priceTo);
             try {
-                $this->addAmount->addTo($pair->getSymbol(), $amount, $priceFrom, $priceTo);
+                foreach ($addTo as $result) {
+                    /** @var \Kobens\Gemini\TradeRepeater\Model\Trade $trade */
+                    $trade = $result['trade'];
+                    $amount = $result['amount'];
+                    $newAmount = Add::getResult($amount, $trade->getBuyAmount());
+                    $output->writeln(sprintf(
+                        'Amount of %s added to %s record. Was buy %s %s @ %s %s/%s, now buy %s',
+                        $amount,
+                        $trade->getSymbol(),
+                        $trade->getBuyAmount(),
+                        strtoupper($pair->getBase()->getSymbol()),
+                        $trade->getBuyPrice(),
+                        strtoupper($pair->getBase()->getSymbol()),
+                        strtoupper($pair->getQuote()->getSymbol()),
+                        $newAmount
+                    ));
+                }
             } catch (\Throwable $e) {
                 $exitCode = 1;
                 $output->writeln(sprintf(

--- a/src/Command/Command/TradeRepeater/Archiver.php
+++ b/src/Command/Command/TradeRepeater/Archiver.php
@@ -6,6 +6,8 @@ namespace Kobens\Gemini\Command\Command\TradeRepeater;
 
 use Kobens\Core\EmergencyShutdownInterface;
 use Kobens\Core\SleeperInterface;
+use Kobens\Gemini\Command\Traits\KillFile;
+use Kobens\Gemini\TradeRepeater\Model\Trade;
 use Kobens\Gemini\TradeRepeater\Model\Resource\Trade\Action\ArchiveInterface;
 use Kobens\Gemini\TradeRepeater\Model\Resource\Trade\Action\SellFilledInterface;
 use Kobens\Gemini\TradeRepeater\Model\Trade\Profits\ProcessorInterface;
@@ -14,12 +16,18 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Zend\Db\Adapter\Driver\ConnectionInterface;
+use Kobens\Gemini\TradeRepeater\Model\Trade\CalculateCompletedProfits;
+use Kobens\Gemini\Exchange\Currency\Pair;
+use Kobens\Math\BasicCalculator\Compare;
+use Kobens\Core\Db;
 
 final class Archiver extends Command
 {
     use SleeperTrait;
+    use KillFile;
 
     private const DEFAULT_DELAY = 2;
+    private const KILL_FILE = 'kill_repeater_archiver';
 
     protected static $defaultName = 'repeater:archiver';
 
@@ -64,41 +72,82 @@ final class Archiver extends Command
         if ($delay <= 0) {
             $delay = self::DEFAULT_DELAY;
         }
-        while (!$this->shutdown->isShutdownModeEnabled()) {
+        while ($this->shutdown->isShutdownModeEnabled() === false && $this->killFileExists(self::KILL_FILE) === false) {
             try {
                 $this->mainLoop($output);
                 $this->sleep($delay, $this->sleeper, $this->shutdown);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $this->shutdown->enableShutdownMode($e);
             }
         }
-        $output->writeln(sprintf(
-            "<fg=red>%s\tShutdown signal detected - %s",
-            $this->now(),
-            self::class
-        ));
+        if ($this->shutdown->isShutdownModeEnabled()) {
+            $output->writeln(sprintf(
+                "<fg=red>%s\tShutdown signal detected - %s",
+                $this->now(),
+                self::class
+            ));
+        }
+        if ($this->killFileExists(self::KILL_FILE)) {
+            $output->writeln(sprintf(
+                "<fg=red>%s\tKill File Detected - %s",
+                $this->now(),
+                self::class
+            ));
+        }
         return 0;
     }
 
     private function mainLoop(OutputInterface $output): void
     {
-        /** @var \Kobens\Gemini\TradeRepeater\Model\Trade $row */
-        foreach ($this->sellFilled->getHealthyRecords() as $row) {
+        /** @var Trade $repeater */
+        foreach ($this->sellFilled->getHealthyRecords() as $trade) {
             $this->connection->beginTransaction();
             try {
-                $this->archive->addArchive($row);
-                $this->sellFilled->setNextState($row->getId());
-                $this->processor->execute($row);
+                $this->archive->addArchive($trade);
+                $this->sellFilled->setNextState($trade->getId());
+                $this->processor->execute($trade);
                 $this->connection->commit();
             } catch (\Throwable $e) {
-                $this->connection->rollback();
+                if (Db::isInTransaction()) {
+                    $this->connection->rollback();
+                }
                 throw $e;
             }
-            $output->writeln(sprintf(
-                "%s\t(%d)\t<fg=yellow>ARCHIVED</>",
-                $this->now(),
-                $row->getId()
-            ));
+            $this->reportProfits($output, $trade);
+        }
+    }
+
+    private function reportProfits(OutputInterface $output, Trade $trade): void
+    {
+        $pair = Pair::getInstance($trade->getSymbol());
+        $base = $pair->getBase()->getSymbol();
+        $quote = $pair->getQuote()->getSymbol();
+        $output->writeln(sprintf(
+            "%s\t(%d)\t<fg=yellow>ARCHIVED\tBUY %s %s @ %s %s/%s --- SELL %s %s @ %s %s/%s</>",
+            $this->now(),
+            $trade->getId(),
+            $trade->getBuyAmount(),
+            strtoupper($base),
+            $trade->getBuyPrice(),
+            strtoupper($base),
+            strtoupper($quote),
+            $trade->getSellAmount(),
+            strtoupper($base),
+            $trade->getSellPrice(),
+            strtoupper($base),
+            strtoupper($quote)
+        ));
+        $profits = CalculateCompletedProfits::get($trade);
+        foreach ([$base, $quote] as $symbol) {
+            $profit = $profits[$symbol];
+            if (Compare::getResult($profit, '0') === Compare::LEFT_GREATER_THAN) {
+                $output->writeln(sprintf(
+                    "%s\tProfit: %s %s",
+                    $this->now(),
+                    $profit,
+                    strtoupper($symbol)
+                ));
+            }
         }
     }
 

--- a/src/Command/Command/TradeRepeater/CliMonitor/Account.php
+++ b/src/Command/Command/TradeRepeater/CliMonitor/Account.php
@@ -192,9 +192,7 @@ final class Account extends Command
             if ($amount || $amountNotional || $amountAvailable || $amountAvailableNotional) {
                 $data[] = Balances::getTable($output, $this->data, $amount, $amountNotional, $amountAvailable, $amountAvailableNotional);
             }
-            foreach ($this->profits->get($output) as $table) {
-                $data[] = $table;
-            }
+            $data[] = $this->profits->get($output);
         } catch (\Kobens\Gemini\Exception $e) {
             $data[] = (new Table($output))->addRow([$e->getMessage()]);
         }

--- a/src/Command/Command/TradeRepeater/CliMonitor/Account.php
+++ b/src/Command/Command/TradeRepeater/CliMonitor/Account.php
@@ -13,8 +13,6 @@ use Kobens\Gemini\TradeRepeater\CliMonitor\Balances;
 use Kobens\Gemini\TradeRepeater\CliMonitor\Helper\Data;
 use Kobens\Gemini\TradeRepeater\CliMonitor\Profits;
 use Kobens\Http\Exception\Status\ServerErrorException;
-use Kobens\Math\BasicCalculator\Add;
-use Kobens\Math\BasicCalculator\Multiply;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,7 +21,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Zend\Db\Adapter\Adapter;
 use Zend\Db\TableGateway\TableGatewayInterface;
 use Zend\Db\TableGateway\TableGateway;
-use Zend\Db\Sql\Select;
 
 final class Account extends Command
 {

--- a/src/Command/Traits/KillFile.php
+++ b/src/Command/Traits/KillFile.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kobens\Gemini\Command\Traits;
+
+use Kobens\Core\Config;
+
+trait KillFile
+{
+    private function killFileExists(string $file): bool
+    {
+        $filename = Config::getInstance()->getRootDir() . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . $file;
+        $exists = file_exists($filename);
+        return $exists;
+    }
+}

--- a/src/TradeRepeater/CliMonitor/Profits.php
+++ b/src/TradeRepeater/CliMonitor/Profits.php
@@ -61,6 +61,7 @@ final class Profits
             );
             $table->addRow($row);
         }
+        $table->addRow(['', '', '', '', '']);
         $table->addRow([
             new TableCell('Total Notional', ['colspan' => 2]),
             $cellsAllTime['total_notional'],

--- a/src/TradeRepeater/Model/Trade/AddAmount.php
+++ b/src/TradeRepeater/Model/Trade/AddAmount.php
@@ -93,7 +93,7 @@ final class AddAmount
         return $amountAdded;
     }
 
-    public function addTo(string $symbol, string $amount, string $priceFrom, string $priceTo): void
+    public function addTo(string $symbol, string $amount, string $priceFrom, string $priceTo): \Generator
     {
         $rows = $this->tradeResource->getList(
             $symbol,
@@ -105,7 +105,11 @@ final class AddAmount
         );
         /** @var Trade $row */
         foreach ($rows as $row) {
-            $this->add($row->getId(), $amount);
+            $amount = $this->add($row->getId(), $amount);
+            yield [
+                'trade' => $row,
+                'amount' => $amount,
+            ];
         }
     }
 


### PR DESCRIPTION
- TECH DEBT: Cleaned up unused use statements
- TECH DEBT: upgraded `kobens/kobens-core`
- FEATURE: `CliMonitor\Account` has had its profits table(s) condensed into a single table with more columns. Also added columns for statistics on past 30 days of trading activity.
- BUGFIX: Fixed a bug in `bin/trade-repeater` where the `repeater:archiver` command would not start if the `repeater:archiver:fill-time` command was already running.
- FEATURE: Repeater Commands now all have individual kill files, allowing us to stop individual processes without having to shut down the entire trading operation.