### PR TITLE
Fix #121 - cannot divide by zero

### DIFF
--- a/src/TradeRepeater/Model/Trade/AddAmount.php
+++ b/src/TradeRepeater/Model/Trade/AddAmount.php
@@ -220,12 +220,16 @@ final class AddAmount
             $safeToAdd = true;
         } else {
             // Is current market bid a safe threshold percentage higher than original bid
-            $percent = Multiply::getResult(
-                Divide::getResult($trade->getBuyPrice(), $spread, 4),
-                '100'
-            );
-            if (Compare::getResult($percent, self::BUY_THRESHOLD) === Compare::LEFT_GREATER_THAN) {
-                $safeToAdd = true;
+            if (Compare::getResult($spread, '0') === Compare::EQUAL) {
+                $safeToAdd = false;
+            } else {
+                $percent = Multiply::getResult(
+                    Divide::getResult($trade->getBuyPrice(), $spread, 4),
+                    '100'
+                );
+                if (Compare::getResult($percent, self::BUY_THRESHOLD) === Compare::LEFT_GREATER_THAN) {
+                    $safeToAdd = true;
+                }
             }
         }
         return $safeToAdd;


### PR DESCRIPTION
When the current bid for the asset is equal to the `buy_price` for the record, the spread is `0`. There is no point in attempting to Divide the spread by the buy price then to determine the % as this causes an error and we already know the % spread is 0% therefore not safe to attempt to add to it.