### PR TITLE
adjust maximums

### DIFF
--- a/install/db/schema_throttler.sql
+++ b/install/db/schema_throttler.sql
@@ -15,9 +15,9 @@ CREATE TABLE `throttler` (
 INSERT INTO `throttler` (`id`,`max`)
 VALUES
   ('api.sandbox.gemini.com::public',  2),
-  ('api.sandbox.gemini.com::private', 10),
+  ('api.sandbox.gemini.com::private', 8),
   ('api.gemini.com::public',  2),
-  ('api.gemini.com::private', 10)
+  ('api.gemini.com::private', 8)
 ;
 
 


### PR DESCRIPTION
while prior to the limits were set to what their documentation states, this did not reliably prevent rate limit violations from occurring. My guess is due to the HTTP requests of loggers. The throttler also does not take into account certain edge cases which I am too drunk to describe in this commit message.